### PR TITLE
Add support for container links

### DIFF
--- a/docker-compose-dot.go
+++ b/docker-compose-dot.go
@@ -30,14 +30,14 @@ type volume struct {
 }
 
 type service struct {
-	ContainerName                     string "container_name"
-	Image                             string
-	Networks, Ports, Volumes, Command []string
-	VolumesFrom                       []string "volumes_from"
-	DependsOn                         []string "depends_on"
-	CapAdd                            []string "cap_add"
-	Build                             struct{ Context, Dockerfile string }
-	Environment                       map[string]string
+	ContainerName                            string "container_name"
+	Image                                    string
+	Networks, Ports, Volumes, Command, Links []string
+	VolumesFrom                              []string "volumes_from"
+	DependsOn                                []string "depends_on"
+	CapAdd                                   []string "cap_add"
+	Build                                    struct{ Context, Dockerfile string }
+	Environment                              map[string]string
 }
 
 func nodify(s string) string {
@@ -142,6 +142,16 @@ func main() {
 			for _, linkTo := range service.DependsOn {
 				graph.AddEdge(nodify(name), nodify(linkTo), true,
 					map[string]string{"style": "dashed", "label": "depends_on"})
+			}
+		}
+		// links
+		if service.Links != nil {
+			for _, linkTo := range service.Links {
+				if strings.Contains(linkTo, ":") {
+					linkTo = strings.Split(linkTo, ":")[0]
+				}
+				graph.AddEdge(nodify(name), nodify(linkTo), true,
+					map[string]string{"style": "dashed", "label": "links"})
 			}
 		}
 	}


### PR DESCRIPTION
This pull request adds support for the [links](https://docs.docker.com/compose/compose-file/compose-file-v2/#links) directive. Links are displayed the same way as the `depends_on` connections.

BTW: Thanks for providing this tool.